### PR TITLE
fix: log unregistered users as info and not error

### DIFF
--- a/app/mails/management/commands/import.py
+++ b/app/mails/management/commands/import.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
             account = user.get_account()
         except:
             message.delete()
-            logger.error("Mail from %s deleted: User not registered" % sender)
+            logger.info("Mail from %s deleted: User not registered" % sender)
             tools.send_registration_mail(sender)
 
             return


### PR DESCRIPTION
An unregistered user in the app is not strictly an error. Often times
this gets triggered by spam and it isn't usually an error that we need
to take care of (as in rmd is working nominally when it rejects an
unregistered email).